### PR TITLE
feat(memory): implement token-aware context window management (#15)

### DIFF
--- a/src/main/java/dev/prasadgaikwad/openclaw4j/memory/ShortTermMemory.java
+++ b/src/main/java/dev/prasadgaikwad/openclaw4j/memory/ShortTermMemory.java
@@ -1,5 +1,9 @@
 package dev.prasadgaikwad.openclaw4j.memory;
 
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.stereotype.Component;
 
@@ -20,20 +24,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * </p>
  *
  * <p>
- * To manage resource consumption, the memory implements a simple sliding-window
- * eviction policy, retaining only the last {@value #MAX_HISTORY_SIZE} messages
- * per context.
+ * To manage resource consumption, the memory implements a token-aware context
+ * management strategy, retaining messages until the total token count exceeds
+ * {@value #MAX_TOKENS_FOR_HISTORY}.
  * </p>
- *
- * <h3>Usage Example:</h3>
- * 
- * <pre>
- * // Storing a message
- * shortTermMemory.addMessage("C12345", new UserMessage("Hello!"));
- *
- * // Retrieving history
- * List&lt;Message&gt; history = shortTermMemory.getHistory("C12345");
- * </pre>
  *
  * @author Prasad Gaikwad
  */
@@ -41,7 +35,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ShortTermMemory {
 
     private final Map<String, List<Message>> conversationHistory = new ConcurrentHashMap<>();
-    private static final int MAX_HISTORY_SIZE = 50; // Simple eviction policy
+    private static final int MAX_TOKENS_FOR_HISTORY = 4000;
+    private final Encoding encoding;
+
+    public ShortTermMemory() {
+        EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
+        // O200K_BASE is used by GPT-4o models
+        this.encoding = registry.getEncoding(EncodingType.O200K_BASE);
+    }
 
     public void addMessage(String contextId, Message message) {
         conversationHistory.compute(contextId, (key, history) -> {
@@ -49,9 +50,16 @@ public class ShortTermMemory {
                 history = new ArrayList<>();
             }
             history.add(message);
-            // Simple eviction: keep last N messages
-            if (history.size() > MAX_HISTORY_SIZE) {
-                return new ArrayList<>(history.subList(history.size() - MAX_HISTORY_SIZE, history.size()));
+
+            int currentTokens = countTokens(history);
+
+            // Dynamic eviction: drop oldest messages while preserving the total token limit
+            // We keep at least one message (the most recent one) even if it's very large
+            while (currentTokens > MAX_TOKENS_FOR_HISTORY && history.size() > 1) {
+                Message removed = history.remove(0);
+                if (removed.getText() != null) {
+                    currentTokens -= encoding.countTokens(removed.getText());
+                }
             }
             return history;
         });
@@ -63,5 +71,16 @@ public class ShortTermMemory {
 
     public void clear(String contextId) {
         conversationHistory.remove(contextId);
+    }
+
+    private int countTokens(List<Message> messages) {
+        int total = 0;
+        for (Message msg : messages) {
+            String content = msg.getText();
+            if (content != null) {
+                total += encoding.countTokens(content);
+            }
+        }
+        return total;
     }
 }

--- a/src/test/java/dev/prasadgaikwad/openclaw4j/memory/ShortTermMemoryTest.java
+++ b/src/test/java/dev/prasadgaikwad/openclaw4j/memory/ShortTermMemoryTest.java
@@ -1,0 +1,68 @@
+package dev.prasadgaikwad.openclaw4j.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShortTermMemoryTest {
+
+    private ShortTermMemory shortTermMemory;
+
+    @BeforeEach
+    void setUp() {
+        shortTermMemory = new ShortTermMemory();
+    }
+
+    @Test
+    void shouldStoreAndRetrieveMessages() {
+        String contextId = "test-context";
+        UserMessage message1 = new UserMessage("Hello");
+        AssistantMessage message2 = new AssistantMessage("Hi there!");
+
+        shortTermMemory.addMessage(contextId, message1);
+        shortTermMemory.addMessage(contextId, message2);
+
+        List<Message> history = shortTermMemory.getHistory(contextId);
+        assertThat(history).hasSize(2);
+        assertThat(history.get(0)).isEqualTo(message1);
+        assertThat(history.get(1)).isEqualTo(message2);
+    }
+
+    @Test
+    void shouldEvictOldMessagesWhenTokenLimitExceeded() {
+        String contextId = "overflow-context";
+
+        // Add a very large message (limit is 4000 tokens)
+        // A long string of "a " repeated many times
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 5000; i++) {
+            sb.append("word ");
+        }
+        String longContent = sb.toString();
+
+        shortTermMemory.addMessage(contextId, new UserMessage("First small message"));
+        shortTermMemory.addMessage(contextId, new UserMessage(longContent));
+
+        List<Message> history = shortTermMemory.getHistory(contextId);
+
+        // The first message should be evicted because the second one alone is likely >
+        // 4000 tokens
+        // and addMessage loop continues until currentTokens <= limit OR size == 1.
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).getText()).isEqualTo(longContent);
+    }
+
+    @Test
+    void shouldClearHistory() {
+        String contextId = "clear-context";
+        shortTermMemory.addMessage(contextId, new UserMessage("Clear me"));
+        shortTermMemory.clear(contextId);
+        assertThat(shortTermMemory.getHistory(contextId)).isEmpty();
+    }
+}


### PR DESCRIPTION
Resolves #15.

### Changes
- Integrates `JTokkit` for token estimation in `ShortTermMemory`.
- Replaces fixed 50-message limit with a dynamic 4,000-token threshold.
- Ensures the model's context window is not overwhelmed by long histories or tool outputs.
- Added unit tests to verify the eviction logic.