### PR TITLE
docs: add detailed feature reference guides under docs/reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ User receives agent response
 | **Advanced Heartbeat** | Periodic checks with system-wide event broadcasting |
 | **RAG Toggle** | Feature flag to disable RAG by default (`openclaw4j.rag.enabled`) |
 
+## Feature References
+
+Detailed documentation for each implemented feature can be found in the [**Feature Reference Index**](./docs/reference/README.md).
+
+-   [**Memory Reference**](./docs/reference/memory.md)
+-   [**Profile & Identity Reference**](./docs/reference/profile.md)
+-   [**Search Reference**](./docs/reference/search.md)
+-   [**RAG Reference**](./docs/reference/rag.md)
+-   [**Slack Reference**](./docs/reference/slack.md)
+-   [**Reminders Reference**](./docs/reference/reminders.md)
+-   [**Date & Time Reference**](./docs/reference/datetime.md)
+
 ## Technology Stack
 
 | Component | Technology |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,13 @@
+# Feature Reference Documentation
+
+This directory contains detailed technical references for each major feature implemented in OpenClaw4J. These guides explain the capabilities, available tools, and underlying mechanisms for each feature.
+
+## Available Guides
+
+-   [**Memory Reference**](./memory.md): Long-term memory (`MEMORY.md`), searching, and daily history logs.
+-   [**Profile & Identity Reference**](./profile.md): User preferences (`USER.md`), agent soul (`SOUL.md`), and environment facts (`TOOLS.md`).
+-   [**Search Reference**](./search.md): Web search capabilities powered by Tavily AI.
+-   [**RAG Reference**](./rag.md): Retrieval-Augmented Generation for semantic knowledge retrieval.
+-   [**Slack Reference**](./slack.md): Slack-specific tools, channel history, and message formatting.
+-   [**Reminders Reference**](./reminders.md): Scheduled one-time and recurring (cron) reminders.
+-   [**Date & Time Reference**](./datetime.md): Temporal awareness and current system context.

--- a/docs/reference/datetime.md
+++ b/docs/reference/datetime.md
@@ -1,0 +1,19 @@
+# Date and Time Reference
+
+OpenClaw4J includes a temporal awareness tool that allows it to maintain the correct current context for scheduling and answering user questions about time.
+
+## Features
+
+-   **System Access**: Retrieves the system's current datetime.
+-   **Contextualization**: Adjusted for the user's locale and timezone where possible.
+
+## Available Tools
+
+#### `getCurrentDateTime()`
+Returns the current date and time in a human-readable format, including the timezone. Use this whenever the user asks "What time is it?" or when you need to calculate relative times (e.g. "in 5 minutes").
+
+---
+
+## Technical Details
+
+The `DateTimeTools` class interacts with `LocalDateTime` and uses the `LocaleContextHolder` to provide the current system context for each tool call.

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -1,0 +1,49 @@
+# Memory Reference
+
+OpenClaw4J features a multi-layered memory system that allows the agent to retain information across sessions and track historical events.
+
+## Long-Term Memory (MEMORY.md)
+
+Long-term memory is used to store curated facts, user preferences, and important decisions that should persist indefinitely.
+
+### Features
+
+-   **Persistence**: Facts are saved to `.memory/MEMORY.md`.
+-   **Structure**: Memories are stored as a bulleted list of strings.
+-   **Curation**: The agent can explicitly decide what to remember, search for, or delete.
+
+### Available Tools
+
+#### `remember(String fact)`
+Saves an important fact or user preference into long-term memory for future recall. Use this when the user explicitly asks you to remember something or when you identify a piece of information that will be useful in future conversations.
+
+#### `searchMemory(String query)`
+Searches the `MEMORY.md` file for lines matching a keyword or phrase (case-insensitive). This is useful when you need to recall specific information that might not be in the immediate context.
+
+#### `forgetFact(String fact)`
+Removes a specific fact from long-term memory. Use this to clean up obsolete or incorrect information. It matches lines containing the provided string.
+
+#### `updateFact(String oldFact, String newFact)`
+Replaces an existing fact in long-term memory with a updated version. This is the preferred way to correct or evolve stored information without losing context.
+
+---
+
+## Daily History Logs
+
+Daily logs capture raw events, scratch notes, and a chronological record of interactions.
+
+### Features
+
+-   **Daily Rotation**: Logs are stored in `.memory/daily/YYYY-MM-DD.md`.
+-   **Raw Record**: Useful for debugging, auditing, or retrieving snippets of past conversations that aren't "curated" into long-term memory.
+
+### Available Tools
+
+#### `logEvent(String event)`
+Logs a raw event or scratch note to the current day's log file. These are timestamped automatically.
+
+#### `listHistory()`
+Lists all dates for which a daily history log exists. Returns a list in `YYYY-MM-DD` format.
+
+#### `readHistoryLog(String date)`
+Retrieves the full content of the daily history log for a specific date.

--- a/docs/reference/profile.md
+++ b/docs/reference/profile.md
@@ -1,0 +1,30 @@
+# Profile and Identity Reference
+
+The profile defines who OpenClaw4J is and how it should behave. It manages the user's personality, core instructions, and specific preferences.
+
+## Features
+
+-   **User Identity**: Stores the user's name and preferred tone.
+-   **Soul Definition**: Defines the agent's personality and soul for behavioral consistency.
+-   **Environment Base**: Stays aware of its operating context (e.g., Development, Server URL).
+
+## Available Tools
+
+#### `updateUserPreference(String key, String value)`
+Updates a specific user preference in the profile (`USER.md`). The key can be any string (e.g., `tone`, `notification_settings`).
+
+#### `updateSoul(String soulContent)`
+Updates the agent's core personality and soul definition in `SOUL.md`. This allows the agent's behavior and responses to evolve as the relationship with the user develops.
+
+#### `updateEnvironmentFact(String fact)`
+Adds an environmental fact to `TOOLS.md` (e.g., repository names, server URLs). These are used to ground the agent's knowledge in its current environment.
+
+---
+
+## Configuration Files
+
+The profile is backed by files in the `.memory/profiles/` directory:
+
+-   **`USER.md`**: Contains the user's name and preference list.
+-   **`SOUL.md`**: Defines the agent's behavioral persona.
+-   **`TOOLS.md`**: Stores environmental facts and tool-specific constants.

--- a/docs/reference/rag.md
+++ b/docs/reference/rag.md
@@ -1,0 +1,20 @@
+# RAG Reference
+
+Retrieval-Augmented Generation (RAG) is used to search indexed channel history and documentation stored in the agent's knowledge base.
+
+## Features
+
+-   **Semantic Retrieval**: Uses a vector store for search, performing better than keyword matches for complex queries.
+-   **Contextual Sourcing**: Retrieves specific snippets of past channel discussions and documentation.
+-   **Traceability**: Each document chunk is returned with a timestamp for better context.
+
+## Available Tools
+
+#### `searchKnowledgeBase(String query)`
+Searches the user-provided knowledge base for information matching the query. This is the primary way to access information from past discussions, documentation, and technical notes that are too large for memory.
+
+---
+
+## Vector Store Integration
+
+OpenClaw4J uses Spring AI's vector store abstraction, supporting multiple backends like PGVector. Documents are automatically split and indexed for enhanced relevance during retrieval.

--- a/docs/reference/reminders.md
+++ b/docs/reference/reminders.md
@@ -1,0 +1,28 @@
+# Reminders Reference
+
+OpenClaw4J can schedule and manage one-time or recurring reminders using an asynchronous scheduling engine.
+
+## Features
+
+-   **Automatic Context**: You don't need to specify the user, channel, or thread details—they're automatically read from the conversation context.
+-   **Precision Scheduling**: Supports full ISO-8601 datetimes.
+-   **Recurring Tasks**: Uses Spring-compatible 6-part cron expressions.
+
+## Available Tools
+
+#### `setReminder(String content, String remindAt)`
+Sets a one-time reminder for the current user. Use this when the user says "Remind me to [content] in [duration]" or "Remind me at [time]".
+
+-   `content`: What should the user be reminded of?
+-   `remindAt`: Must be a full ISO-8601 datetime with a timezone offset (e.g. `2026-02-20T22:00:00-06:00`).
+
+#### `setCronReminder(String content, String cronExpression)`
+Sets a recurring reminder using a cron schedule. Use this when the user says "Remind me to [content] every [weekday] at [time]".
+
+-   `cronExpression`: A Spring-compatible 6-part cron expression (e.g. `0 0 9 * * MON` for every Monday at 9am).
+
+---
+
+## Technical Details
+
+Reminders are managed by a `ReminderEngine` that persists them (if configured) or executes them as scheduled tasks. Each reminder captures its originating channel and thread to ensure it's delivered back to the correct context.

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -1,0 +1,26 @@
+# Search Reference
+
+OpenClaw4J uses the Tavily AI search engine to find the latest information on the internet.
+
+## Features
+
+-   **Deep Search**: Capabilities for a deeper or broader search of the web.
+-   **AI Summarization**: Returns both a consolidated list of results and an AI-generated summary.
+-   **Contextualization**: This tool is ideal for current events, news, or any information not present in the internal knowledge base.
+
+## Available Tools
+
+#### `search(String query)`
+Performs a web search based on the query. It returns a consolidated string of the top results, including titles, URLs, and snippets. Use this whenever you're unsure about factual data that could have changed after your training cutoff.
+
+---
+
+## Configuration
+
+Search properties are configured in `application.yml` or through environment variables:
+
+-   `openclaw4j.tools.search.enabled`: Global toggle to enable the search tool.
+-   `openclaw4j.tools.search.api-key`: Your Tavily API key.
+-   `openclaw4j.tools.search.search-depth`: How deep to search (e.g., `basic` or `advanced`).
+-   `openclaw4j.tools.search.max-results`: Number of results to return.
+-   `openclaw4j.tools.search.include-answer`: Whether to include an AI-synthesized answer in the response.

--- a/docs/reference/slack.md
+++ b/docs/reference/slack.md
@@ -1,0 +1,28 @@
+# Slack Reference
+
+The Slack integration provides OpenClaw4J with its primary communication channel, allowing it to interact with users directly in their workspace.
+
+## Features
+
+-   **Message Dispatch**: Handled primarily via the `SlackChannelAdapter`.
+-   **Formatted Output**: Automatically formats markdown to its Slack equivalent.
+-   **Independent Messaging**: Allows the agent to post messages or fetch context independently of its main response loop.
+
+## Available Tools
+
+#### `postSlackMessage(String channelId, String text)`
+Posts a message to a Slack channel. Most useful for broad communication, status updates, or when you need to send information to a different channel from where the conversation originated.
+
+#### `getChannelHistory(String channelId, Integer limit)`
+Retrieves recent messages from a channel to gain context on a conversation or thread. This is useful for recalling details of a past discussion or understanding the state of a thread.
+
+---
+
+## Slack Formatting
+
+Slack message formatting is distinct from standard Markdown. OpenClaw4J includes a `SlackFormatter` that automatically converts:
+
+-   Bold (`**text**` $\rightarrow$ `*text*`)
+-   Italic (`*text*` $\rightarrow$ `_text_`)
+-   Links (`[label](url)` $\rightarrow$ `<url|label>`)
+-   Lists and code blocks.


### PR DESCRIPTION
### Overview
This PR introduces a comprehensive feature reference guide under `docs/reference/`. These documents provide technical details and usage instructions for the agent's core capabilities, including tool availability and underlying data structures.

### Key Changes
- **New Directory**: Created `docs/reference/` for dedicated tool documentation.
- **Reference Guides**: Added guides for:
  - `memory.md`: Long-term memory, curation, and historical search.
  - `profile.md`: User preferences, personality (soul), and environment facts.
  - `search.md`: Tavily search integration.
  - `rag.md`: RAG architecture and knowledge retrieval.
  - `slack.md`: Slack channel tools and message formatting.
  - `reminders.md`: Asynchronous task scheduling (one-time and cron).
  - `datetime.md`: Temporal awareness.
- **Index**: Created `docs/reference/README.md` to serve as a navigable hub.
- **README Overlay**: Updated the root `README.md` to link directly to these reference documents.

### Issue
Fixes #37.